### PR TITLE
Improve object deletion.

### DIFF
--- a/pkg/test/runner.go
+++ b/pkg/test/runner.go
@@ -195,6 +195,9 @@ func Run(testDoc *doc.Document, opts ...RunOpt) error {
 	tc.regoDriver.StoreItem("/test/params/run-id", tc.envDriver.UniqueID())
 
 	step(tc.recorder, "compiling test document", func() {
+		tc.recorder.Update(
+			result.Infof("test run ID is %s", tc.envDriver.UniqueID()))
+
 		compiler, err = compileDocument(testDoc, tc.policyModules)
 		if err != nil {
 			tc.recorder.Update(result.Fatalf("%s", err.Error()))
@@ -394,8 +397,14 @@ func Run(testDoc *doc.Document, opts ...RunOpt) error {
 		}
 	}
 
-	if !tc.preserve {
-		must.Must(tc.objectDriver.DeleteAll())
+	if tc.preserve {
+		step(tc.recorder, "preserving test objects", func() {})
+	} else {
+		step(tc.recorder, "deleting test objects", func() {
+			if err := tc.objectDriver.DeleteAll(); err != nil {
+				tc.recorder.Update(result.Fatalf("object deletion failed: %s", err))
+			}
+		})
 	}
 
 	// TODO(jpeach): return a structured test result object.

--- a/pkg/utils/kubernetes.go
+++ b/pkg/utils/kubernetes.go
@@ -26,12 +26,10 @@ import (
 
 // ImmediateDeletionOptions returns metav1.DeleteOptions specifying
 // that the caller requires immediate foreground deletion semantics.
-func ImmediateDeletionOptions() *metav1.DeleteOptions {
-	fg := metav1.DeletePropagationForeground
-
+func ImmediateDeletionOptions(propagation metav1.DeletionPropagation) *metav1.DeleteOptions {
 	return &metav1.DeleteOptions{
 		GracePeriodSeconds: pointer.Int64Ptr(0),
-		PropagationPolicy:  &fg,
+		PropagationPolicy:  &propagation,
 	}
 }
 


### PR DESCRIPTION
Previously, we would delete tracked objects, but made no representations
about when the deletion would be completed. Update `DeleteAll` to keep
deleting everything until we receive API server confirmation that the
objects we are tracking are all gone.

This improves test isolation since we have better guarantees that
objects don't leak between runs.

Signed-off-by: James Peach <jpeach@vmware.com>