### PR TITLE
update all copyright information to `Project Contour Authors`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,8 @@
 # Dependency directories (remove the comment below to include it)
 vendor/
 
+# IDE
+.idea/
+
 integration-tester
 pkg/builtin/assets.go

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,4 @@
-# Copyright 2020 VMware, Inc.
+# Copyright  Project Contour Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License.  You may obtain

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 Integration Tester for Kubernetes
-Copyright (c) 2020 VMware, Inc.  All rights reserved.
+Copyright Project Contour Authors
 
 The Apache 2.0 license (the "License") set forth below applies to all
 parts of the integration-tester-for-kubernetes project. You may not use

--- a/cmd/exiterr_test.go
+++ b/cmd/exiterr_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/examples/bad.yaml
+++ b/examples/bad.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 VMware, Inc.
+# Copyright  Project Contour Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License.  You may obtain

--- a/examples/delete.yaml
+++ b/examples/delete.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 VMware, Inc.
+# Copyright  Project Contour Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License.  You may obtain

--- a/examples/double-path.yaml
+++ b/examples/double-path.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 VMware, Inc.
+# Copyright  Project Contour Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License.  You may obtain

--- a/examples/example.yaml
+++ b/examples/example.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 VMware, Inc.
+# Copyright  Project Contour Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License.  You may obtain

--- a/examples/httpbin-fixture.yaml
+++ b/examples/httpbin-fixture.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 VMware, Inc.
+# Copyright  Project Contour Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License.  You may obtain

--- a/examples/pod-restart.yaml
+++ b/examples/pod-restart.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 VMware, Inc.
+# Copyright  Project Contour Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License.  You may obtain

--- a/examples/single-path.yaml
+++ b/examples/single-path.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 VMware, Inc.
+# Copyright  Project Contour Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License.  You may obtain

--- a/examples/status.yaml
+++ b/examples/status.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 VMware, Inc.
+# Copyright  Project Contour Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License.  You may obtain

--- a/examples/validation.yaml
+++ b/examples/validation.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 VMware, Inc.
+# Copyright  Project Contour Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License.  You may obtain

--- a/hack/go-bindata.sh
+++ b/hack/go-bindata.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-# Copyright 2020 VMware, Inc.
+# Copyright  Project Contour Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License.  You may obtain

--- a/hack/insert-copyright.sh
+++ b/hack/insert-copyright.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-# Copyright 2020 VMware, Inc.
+# Copyright  Project Contour Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License.  You may obtain

--- a/hack/make-release-tag.sh
+++ b/hack/make-release-tag.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-# Copyright 2020 VMware, Inc.
+# Copyright  Project Contour Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License.  You may obtain

--- a/hack/tree-version.sh
+++ b/hack/tree-version.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-# Copyright 2020 VMware, Inc.
+# Copyright  Project Contour Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License.  You may obtain

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/builtin/capture.go
+++ b/pkg/builtin/capture.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/builtin/capture_test.go
+++ b/pkg/builtin/capture_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/builtin/tools.go
+++ b/pkg/builtin/tools.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/doc/fragment.go
+++ b/pkg/doc/fragment.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/doc/fragment_test.go
+++ b/pkg/doc/fragment_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/doc/read.go
+++ b/pkg/doc/read.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/doc/read_test.go
+++ b/pkg/doc/read_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/driver/auth.go
+++ b/pkg/driver/auth.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/driver/environment.go
+++ b/pkg/driver/environment.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/driver/handlers.go
+++ b/pkg/driver/handlers.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/driver/kubernetes.go
+++ b/pkg/driver/kubernetes.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/driver/kubernetes_test.go
+++ b/pkg/driver/kubernetes_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/driver/object.go
+++ b/pkg/driver/object.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/driver/rego.go
+++ b/pkg/driver/rego.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/driver/rego_test.go
+++ b/pkg/driver/rego_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/driver/rules.go
+++ b/pkg/driver/rules.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/fixture/fixture.go
+++ b/pkg/fixture/fixture.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/fixture/set.go
+++ b/pkg/fixture/set.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/must/must.go
+++ b/pkg/must/must.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/result/result.go
+++ b/pkg/result/result.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/test/defaults.go
+++ b/pkg/test/defaults.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/test/recorder.go
+++ b/pkg/test/recorder.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/test/runner.go
+++ b/pkg/test/runner.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/test/runner_test.go
+++ b/pkg/test/runner_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/test/summary.go
+++ b/pkg/test/summary.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/test/tapwriter.go
+++ b/pkg/test/tapwriter.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/test/treewriter.go
+++ b/pkg/test/treewriter.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/test/wrap.go
+++ b/pkg/test/wrap.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/utils/bytes.go
+++ b/pkg/utils/bytes.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/utils/bytes_test.go
+++ b/pkg/utils/bytes_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/utils/errchain.go
+++ b/pkg/utils/errchain.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/utils/errchain_test.go
+++ b/pkg/utils/errchain_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/utils/kubernetes.go
+++ b/pkg/utils/kubernetes.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/utils/policy.go
+++ b/pkg/utils/policy.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/utils/policy_test.go
+++ b/pkg/utils/policy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/utils/string.go
+++ b/pkg/utils/string.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/utils/string_test.go
+++ b/pkg/utils/string_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
-// Copyright 2020 VMware, Inc.
+// Copyright  Project Contour Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may
 // not use this file except in compliance with the License.  You may obtain


### PR DESCRIPTION
This updates all references to the copyright information to match
the new string Copyright Project Contour Authors

Signed-off-by: Steve Sloka <slokas@vmware.com>