### PR TITLE
Ignore empty fragments.

### DIFF
--- a/pkg/doc/fragment_test.go
+++ b/pkg/doc/fragment_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// nolint(gocognit)
 func TestParseFragment(t *testing.T) {
 	type testcase struct {
 		Data string
@@ -68,6 +69,13 @@ func TestParseFragment(t *testing.T) {
 				}
 				if f.Rego() == nil {
 					t.Errorf("nil module for rego fragment")
+				}
+			case FragmentTypeEmpty:
+				if f.Object() != nil {
+					t.Errorf("non-nil object for empty fragment")
+				}
+				if f.Rego() != nil {
+					t.Errorf("non-nil module for empty fragment")
 				}
 			default:
 				t.Errorf("invalid fragment type %d", fragType)
@@ -127,5 +135,14 @@ metadata:
 	run(t, "Rego rule", testcase{
 		Data: `t { x := 42; y := 41; x > y }`,
 		Want: FragmentTypeModule,
+	})
+
+	run(t, "Empty fragment", testcase{
+		Data: `
+# commented: out
+# yaml: foo
+
+`,
+		Want: FragmentTypeEmpty,
 	})
 }

--- a/pkg/test/runner.go
+++ b/pkg/test/runner.go
@@ -386,8 +386,8 @@ func Run(testDoc *doc.Document, opts ...RunOpt) error {
 					tc.recorder.Update(checkResults...)
 				})
 
-		case doc.FragmentTypeUnknown:
-			// Ignore unknown fragments.
+		case doc.FragmentTypeUnknown, doc.FragmentTypeEmpty:
+			// Ignore unknown and empty fragments.
 
 		case doc.FragmentTypeInvalid:
 			// XXX(jpeach): We can't get here because


### PR DESCRIPTION
When developing a test document, you might comment out some fragment,
but leave the YAML document separator in place. This should result in
an empty fragment rather than an invalid fragment, since the latter
just generates an annoying and unnecessary error.

Signed-off-by: James Peach <jpeach@vmware.com>