### PR TITLE
Add the filename to Rego fragment locations.

### DIFF
--- a/pkg/doc/read.go
+++ b/pkg/doc/read.go
@@ -35,6 +35,7 @@ type Document struct {
 // YAML document separator (see https://yaml.org/spec/1.0/#id2561718).
 // The contents of each Fragment is opaque and need not be YAML.
 func ReadDocument(in io.Reader) (*Document, error) {
+	filename := ""
 	startLine := 0
 	currentLine := 0
 
@@ -44,6 +45,10 @@ func ReadDocument(in io.Reader) (*Document, error) {
 	doc := Document{}
 
 	scanner := bufio.NewScanner(in)
+
+	if f, ok := in.(*os.File); ok {
+		filename = f.Name()
+	}
 
 	// Scan the input a line at a time.
 	for scanner.Scan() {
@@ -66,8 +71,9 @@ func ReadDocument(in io.Reader) (*Document, error) {
 				doc.Parts = append(doc.Parts, Fragment{
 					Bytes: utils.CopyBytes(buf.Bytes()),
 					Location: Location{
-						Start: startLine,
-						End:   currentLine - 1,
+						Filename: filename,
+						Start:    startLine,
+						End:      currentLine - 1,
 					},
 				})
 			}
@@ -85,8 +91,9 @@ func ReadDocument(in io.Reader) (*Document, error) {
 		doc.Parts = append(doc.Parts, Fragment{
 			Bytes: utils.CopyBytes(buf.Bytes()),
 			Location: Location{
-				Start: startLine,
-				End:   currentLine,
+				Filename: filename,
+				Start:    startLine,
+				End:      currentLine,
 			},
 		})
 	}

--- a/pkg/utils/policy.go
+++ b/pkg/utils/policy.go
@@ -43,15 +43,20 @@ func ParseModuleFile(filePath string) (*ast.Module, error) {
 // Rego input is assumed to not have a package declaration so a random
 // package name is prepended to make the parsed module globally unique.
 // ParseCheckFragment can return nil with no error if the input is empty.
-func ParseCheckFragment(input string) (*ast.Module, error) {
+// If the filename parameter is empty, an internal name will be generated.
+func ParseCheckFragment(filename string, input string) (*ast.Module, error) {
 	// Rego requires a package name to generate any Rules.  Force
 	// a package name that is unique to the fragment.  Note that
 	// we also use this to generate a unique filename placeholder
 	// since Rego internals will sometime use this as a map key.
 	moduleName := RandomStringN(12)
 
+	if filename == "" {
+		filename = fmt.Sprintf("internal/check/%s", moduleName)
+	}
+
 	m, err := ast.ParseModule(
-		fmt.Sprintf("internal/check/%s", moduleName),
+		filename,
 		fmt.Sprintf("package check.%s\n%s", moduleName, input))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
It is awkward to map the location of Rego erros back to the right
line on the test document, but we can improve things (in a hacky way)
by capturing the file and line number in the filename that we feed to
Rego when we compile a fragment.

This updates #12.

Signed-off-by: James Peach <jpeach@vmware.com>