### PR TITLE
Ignore Rego error removing non-existent paths.

### DIFF
--- a/pkg/test/runner.go
+++ b/pkg/test/runner.go
@@ -628,5 +628,17 @@ func removeResource(k *driver.KubeClient, c driver.RegoDriver, u *unstructured.U
 		return err
 	}
 
-	return c.RemovePath(pathForResource(gvr.Resource, u))
+	// We don't care if the path we wanted to remove wasn't found,
+	// as long as it's not there when we are done. We can end up
+	// receiving multiple delete events for the same object, which
+	// can attempt to remove the same path again.
+	return ignoreStorageNotFoundErr(c.RemovePath(pathForResource(gvr.Resource, u)))
+}
+
+func ignoreStorageNotFoundErr(err error) error {
+	if storage.IsNotFound(err) {
+		return nil
+	}
+
+	return err
 }


### PR DESCRIPTION
It is possible to get multiple deletion events for objects, in which
case the runner will remove the Rego store path a second time. We don't
care about the "doesn't exist" error in this case because we are pretty
sure we want the path to not exist.

Signed-off-by: James Peach <jpeach@vmware.com>