### PR TITLE
Add explicit `check` results.

### DIFF
--- a/pkg/builtin/checkResult.rego
+++ b/pkg/builtin/checkResult.rego
@@ -1,0 +1,46 @@
+package builtin.result
+
+PassResult := "Pass"
+SkipResult := "Skip"
+ErrorResult := "Error"
+FatalResult := "Fatal"
+
+Pass(msg) = {
+    "result": PassResult,
+    "msg": msg,
+}
+
+Passf(fmt, args) = {
+    "result": PassResult,
+    "msg": sprintf(fmt, args),
+}
+
+Skip(msg) = {
+    "result": SkipResult,
+    "msg": msg,
+}
+
+Skipf(fmt, args) = {
+    "result": SkipResult,
+    "msg": sprintf(fmt, args),
+}
+
+Error(msg) = {
+    "result": ErrorResult,
+    "msg": msg,
+}
+
+Errorf(fmt, args) = {
+    "result": ErrorResult,
+    "msg": sprintf(fmt, args),
+}
+
+Fatal(msg) = {
+    "result": FatalResult,
+    "msg": msg,
+}
+
+Fatalf(fmt, args) = {
+    "result": FatalResult,
+    "msg": sprintf(fmt, args),
+}

--- a/pkg/driver/rules.go
+++ b/pkg/driver/rules.go
@@ -33,6 +33,7 @@ var rules = []ruleInfo{
 	{name: "error", prefix: "error_", severity: result.SeverityError},
 	{name: "fatal", prefix: "fatal_", severity: result.SeverityFatal},
 	{name: "skip", prefix: "skip_", severity: result.SeveritySkip},
+	{name: "check", prefix: "check_", severity: result.SeverityNone},
 }
 
 // matchRuleByName finds the ruleInfo that matches the given query
@@ -77,11 +78,13 @@ func findAssertionRules(m *ast.Module) []string {
 	for _, rule := range m.Rules {
 		name := rule.Head.Name.String()
 
-		if severityForRuleName(name) == result.SeverityNone {
-			continue
+		switch {
+		case name == "check" || strings.HasPrefix(name, "check_"):
+			found[name] = struct{}{}
+		case severityForRuleName(name) != result.SeverityNone:
+			found[name] = struct{}{}
 		}
 
-		found[name] = struct{}{}
 	}
 
 	// Flatten query names back into the slice.

--- a/pkg/result/result.go
+++ b/pkg/result/result.go
@@ -34,6 +34,9 @@ const SeverityFatal Severity = "Fatal"
 // SeveritySkip ...
 const SeveritySkip Severity = "Skip"
 
+// SeverityPass explicitly marks a result as recording a successful check.
+const SeverityPass Severity = "Pass"
+
 // Result ...
 type Result struct {
 	Severity  Severity
@@ -99,4 +102,18 @@ func Contains(results []Result, wanted Severity) bool {
 	}
 
 	return false
+}
+
+// OnlyFailed returns a copy of results that only includes failed
+// results.
+func OnlyFailed(results []Result) []Result {
+	var failed []Result
+
+	for _, r := range results {
+		if r.IsFailed() {
+			failed = append(failed, r)
+		}
+	}
+
+	return failed
 }

--- a/pkg/test/runner.go
+++ b/pkg/test/runner.go
@@ -522,15 +522,16 @@ func runCheck(
 			return nil, err
 		}
 
-		if len(results) == 0 {
-			return nil, nil
-		}
-
 		// If we have a skip result, skip now rather than
 		// waiting for the timeout. It makes no sense to wait,
-		// since skipping should be a permenent status.
+		// since skipping should be a permanent status.
 		if result.Contains(results, result.SeveritySkip) {
 			return results, err
+		}
+
+		results = result.OnlyFailed(results)
+		if len(results) == 0 {
+			return nil, nil
 		}
 
 		time.Sleep(time.Millisecond * 500)


### PR DESCRIPTION
The problem with using the name of the rule to classify the result is
that it becomes hard to write generally useful checks. For example,
if we need a HTTP response to have a 404 status, we can test for the
status in a policy module, but we still need to wrap that in an error
rule to propagate the result, which makes tests more verbose than they
ought to be.

This change introduces the `check` rule type, where the result of a
rule can be a map with an explicit `result` field. This allows test
authors to write policy modules that are completely self-contained
and can return results independently of the rule type. For example,
it would be possible to have a single policy function that skips a
test if `cert-manager` is not installed.

Signed-off-by: James Peach <jpeach@vmware.com>