### PR TITLE
Fix TAP writer skip status.

### DIFF
--- a/pkg/test/tapwriter.go
+++ b/pkg/test/tapwriter.go
@@ -68,6 +68,8 @@ func (t *TapWriter) NewDocument(desc string) Closer {
 
 	t.docCount++
 	t.stepCount = 0
+	t.stepErrors = nil
+	t.stepSkips = nil
 
 	return CloserFunc(func() {
 		// NOTE, it's a closed interval.


### PR DESCRIPTION
Reset the TAP writer skips when we start a new document. If a test
document was skipped, the skip state was being leaked over to the
next test document.

Signed-off-by: James Peach <jpeach@vmware.com>